### PR TITLE
Add mergeable config

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -1,0 +1,23 @@
+version: 2
+mergeable:
+  - when: 'pull_request.*, pull_request_review.*'
+    name: Approvals check
+    filter:
+      # ignore 'Feedback' PR
+      - do: payload
+        pull_request:
+          title:
+            must_exclude:
+              regex: ^Feedback$
+              regex_flag: none
+    validate:
+      - do: approvals
+        min:
+          count: 1
+        block:
+          changes_requested: true
+        limit:
+          users:
+            - aartdem
+            - therain7
+            - ksenmel


### PR DESCRIPTION
- Add mergeable config which allows you to merge branches only if there is at least one approval
- Approvals are counted only from team members
- The rules above do not apply to GitHub Classroom Feedback PR