### PR TITLE
Rename 'Map' class to avoid conflicts with Kotlin's stdlib

### DIFF
--- a/lib/src/main/kotlin/bstrees/TreeMap.kt
+++ b/lib/src/main/kotlin/bstrees/TreeMap.kt
@@ -1,6 +1,6 @@
 package bstrees
 
-class Map<K : Comparable<K>, V>(treeType: BSTType = BSTType.RedBlack) {
+class TreeMap<K : Comparable<K>, V>(treeType: BSTType = BSTType.RedBlack) {
     enum class BSTType {
         Simple,
         AVL,


### PR DESCRIPTION
Renamed class ```Map``` to ```TreeMap``` to avoid conflicts with [```Map``` interface](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin.collections/-map/) from Kotlin's standard library