### PR TITLE
Implement insert operation of AVL tree

### DIFF
--- a/lib/src/main/kotlin/bstrees/AVLTree.kt
+++ b/lib/src/main/kotlin/bstrees/AVLTree.kt
@@ -7,8 +7,10 @@ class AVLTree<T : Comparable<T>> : SelfBalancingBST<T, AVLNode<T>>() {
     override fun createNewNode(data: T) = AVLNode(data)
     override val balancer = AVLBalancer<T>()
 
+    /** Inserts new node with [data] as its value in the tree */
     override fun insert(data: T) {
-        TODO("Not yet implemented")
+        val insertedNode = insertNode(data)
+        treeRoot = balancer.balanceAfterInsertion(insertedNode)
     }
 
     override fun delete(data: T): T? {

--- a/lib/src/main/kotlin/bstrees/balancers/AVLBalancer.kt
+++ b/lib/src/main/kotlin/bstrees/balancers/AVLBalancer.kt
@@ -1,8 +1,69 @@
 package bstrees.balancers
 
 import bstrees.nodes.AVLNode
+import kotlin.math.max
 
 class AVLBalancer<T : Comparable<T>> : TreeBalancer<T, AVLNode<T>> {
+    /**
+     * Rotates right edge of the [node] counterclockwise.
+     * Returns node that will be in place of the [node] passed
+     *
+     * Calls [updateHeight] to update heights of the nodes affected.
+     * Throws [IllegalArgumentException] if [node] without right child is passed
+     */
+    private fun rotateLeft(node: AVLNode<T>): AVLNode<T> {
+        val rightChild = node.right
+            ?: throw IllegalArgumentException("Node to rotate must have a right child")
+
+        rightChild.parent = node.parent
+        if (node.parent?.left == node) node.parent?.left = rightChild
+        else node.parent?.right = rightChild
+
+        node.right = rightChild.left
+        rightChild.left?.parent = node
+
+        rightChild.left = node
+        node.parent = rightChild
+
+        updateHeight(node)
+        updateHeight(rightChild)
+        return rightChild
+    }
+
+    /**
+     * Rotates left edge of the [node] clockwise.
+     * Returns node that will be in place of the [node] passed
+     *
+     * Calls [updateHeight] to update heights of the nodes affected.
+     * Throws [IllegalArgumentException] if [node] without left child is passed
+     */
+    private fun rotateRight(node: AVLNode<T>): AVLNode<T> {
+        val leftChild = node.left
+            ?: throw IllegalArgumentException("Node to rotate must have a left child")
+
+        leftChild.parent = node.parent
+        if (node.parent?.left == node) node.parent?.left = leftChild
+        else node.parent?.right = leftChild
+
+        node.left = leftChild.right
+        leftChild.right?.parent = node
+
+        leftChild.right = node
+        node.parent = leftChild
+
+        updateHeight(node)
+        updateHeight(leftChild)
+        return leftChild
+    }
+
+    /** Returns height of the [node] in AVL tree. Returns 0 if null passed */
+    private fun getHeight(node: AVLNode<T>?) = node?.height ?: 0
+
+    /** Updates height of the [node] in AVL tree */
+    private fun updateHeight(node: AVLNode<T>) {
+        node.height = max(getHeight(node.left), getHeight(node.right)) + 1
+    }
+
     override fun balanceAfterInsertion(node: AVLNode<T>): AVLNode<T> {
         TODO("Not yet implemented")
     }

--- a/lib/src/main/kotlin/bstrees/balancers/AVLBalancer.kt
+++ b/lib/src/main/kotlin/bstrees/balancers/AVLBalancer.kt
@@ -64,8 +64,49 @@ class AVLBalancer<T : Comparable<T>> : TreeBalancer<T, AVLNode<T>> {
         node.height = max(getHeight(node.left), getHeight(node.right)) + 1
     }
 
-    override fun balanceAfterInsertion(node: AVLNode<T>): AVLNode<T> {
-        TODO("Not yet implemented")
+    /** Returns balance factor of the [node] in AVL tree */
+    private fun balanceFactor(node: AVLNode<T>) =
+        getHeight(node.left) - getHeight(node.right)
+
+    /**
+     * Balances AVL tree after insertion of new element.
+     * Must be called after every insertion with inserted [node] as parameter.
+     * Returns new root of the tree
+     */
+    override tailrec fun balanceAfterInsertion(node: AVLNode<T>): AVLNode<T> {
+        var currentNode = node
+        when (balanceFactor(currentNode)) {
+            // LL or LR
+            2 -> when (balanceFactor(currentNode.left!!)) {
+                // LL
+                1 -> currentNode = rotateRight(currentNode)
+
+                // LR
+                -1 -> {
+                    rotateLeft(currentNode.left!!)
+                    currentNode = rotateRight(currentNode)
+                }
+            }
+
+            // RR or RL
+            -2 -> when (balanceFactor(currentNode.right!!)) {
+                // RR
+                -1 -> currentNode = rotateLeft(currentNode)
+
+                // RL
+                1 -> {
+                    rotateRight(currentNode.right!!)
+                    currentNode = rotateLeft(currentNode)
+                }
+            }
+
+            else -> updateHeight(currentNode)
+        }
+
+        currentNode.parent?.let {
+            return balanceAfterInsertion(it)
+        }
+        return currentNode
     }
 
     override fun balanceAfterDeletion(node: AVLNode<T>): AVLNode<T> {

--- a/lib/src/main/kotlin/bstrees/nodes/AVLNode.kt
+++ b/lib/src/main/kotlin/bstrees/nodes/AVLNode.kt
@@ -4,5 +4,5 @@ class AVLNode<T : Comparable<T>>(override var data: T) : TreeNode<T, AVLNode<T>>
     override var parent: AVLNode<T>? = null
     override var left: AVLNode<T>? = null
     override var right: AVLNode<T>? = null
-    var height = 0
+    var height = 1
 }


### PR DESCRIPTION
Implemented ```balanceAfterInsertion``` in ```AVLBalancer``` which allowed to implement ```insert``` operation on AVL tree.

**No automatic testing was done** but manual tests show that tree balances itself as expected