### PR TITLE
Add read-only public access to treeRoot

### DIFF
--- a/lib/src/main/kotlin/bstrees/AVLTree.kt
+++ b/lib/src/main/kotlin/bstrees/AVLTree.kt
@@ -2,8 +2,11 @@ package bstrees
 
 import bstrees.nodes.AVLNode
 import bstrees.balancers.AVLBalancer
+import bstrees.wrapped.WrappedAVLNode
 
-class AVLTree<T : Comparable<T>> : SelfBalancingBST<T, AVLNode<T>>() {
+class AVLTree<T : Comparable<T>> : SelfBalancingBST<T, AVLNode<T>, WrappedAVLNode<T>>() {
+    override val root get() = treeRoot?.let { WrappedAVLNode(it) }
+
     override fun createNewNode(data: T) = AVLNode(data)
     override val balancer = AVLBalancer<T>()
 

--- a/lib/src/main/kotlin/bstrees/AbstractBSTrees.kt
+++ b/lib/src/main/kotlin/bstrees/AbstractBSTrees.kt
@@ -2,9 +2,11 @@ package bstrees
 
 import bstrees.nodes.TreeNode
 import bstrees.balancers.TreeBalancer
+import bstrees.wrapped.WrappedNode
 
-abstract class BinarySearchTree<T : Comparable<T>, NodeType : TreeNode<T, NodeType>> {
+abstract class BinarySearchTree<T : Comparable<T>, NodeType : TreeNode<T, NodeType>, WrappedNodeType : WrappedNode<T, WrappedNodeType>> {
     protected var treeRoot: NodeType? = null
+    abstract val root: WrappedNodeType?
 
     fun search(data: T): T? = searchNode(data)?.data
 
@@ -71,6 +73,7 @@ abstract class BinarySearchTree<T : Comparable<T>, NodeType : TreeNode<T, NodeTy
     abstract fun delete(data: T): T?
 }
 
-abstract class SelfBalancingBST<T : Comparable<T>, NodeType : TreeNode<T, NodeType>> : BinarySearchTree<T, NodeType>() {
+abstract class SelfBalancingBST<T : Comparable<T>, NodeType : TreeNode<T, NodeType>, WrappedNodeType : WrappedNode<T, WrappedNodeType>> :
+    BinarySearchTree<T, NodeType, WrappedNodeType>() {
     protected abstract val balancer: TreeBalancer<T, NodeType>
 }

--- a/lib/src/main/kotlin/bstrees/RBTree.kt
+++ b/lib/src/main/kotlin/bstrees/RBTree.kt
@@ -2,8 +2,11 @@ package bstrees
 
 import bstrees.nodes.RBNode
 import bstrees.balancers.RBBalancer
+import bstrees.wrapped.WrappedRBNode
 
-class RBTree<T : Comparable<T>> : SelfBalancingBST<T, RBNode<T>>() {
+class RBTree<T : Comparable<T>> : SelfBalancingBST<T, RBNode<T>, WrappedRBNode<T>>() {
+    override val root get() = treeRoot?.let { WrappedRBNode(it) }
+
     override fun createNewNode(data: T) = RBNode(data)
     override val balancer = RBBalancer<T>()
 

--- a/lib/src/main/kotlin/bstrees/SimpleBST.kt
+++ b/lib/src/main/kotlin/bstrees/SimpleBST.kt
@@ -1,8 +1,11 @@
 package bstrees
 
 import bstrees.nodes.SimpleNode
+import bstrees.wrapped.WrappedSimpleNode
 
-class SimpleBST<T : Comparable<T>> : BinarySearchTree<T, SimpleNode<T>>() {
+class SimpleBST<T : Comparable<T>> : BinarySearchTree<T, SimpleNode<T>, WrappedSimpleNode<T>>() {
+    override val root get() = treeRoot?.let { WrappedSimpleNode(it) }
+
     override fun createNewNode(data: T) = SimpleNode(data)
 
     override fun delete(data: T): T? {

--- a/lib/src/main/kotlin/bstrees/TreeMap.kt
+++ b/lib/src/main/kotlin/bstrees/TreeMap.kt
@@ -11,7 +11,7 @@ class TreeMap<K : Comparable<K>, V>(treeType: BSTType = BSTType.RedBlack) {
         override fun compareTo(other: KeyValuePair<K, V>) = key.compareTo(other.key)
     }
 
-    private val tree: BinarySearchTree<KeyValuePair<K, V>, *> = when (treeType) {
+    private val tree: BinarySearchTree<KeyValuePair<K, V>, *, *> = when (treeType) {
         BSTType.Simple -> SimpleBST()
         BSTType.AVL -> AVLTree()
         BSTType.RedBlack -> RBTree()

--- a/lib/src/main/kotlin/bstrees/wrapped/WrappedAVLNode.kt
+++ b/lib/src/main/kotlin/bstrees/wrapped/WrappedAVLNode.kt
@@ -1,0 +1,11 @@
+package bstrees.wrapped
+
+import bstrees.nodes.AVLNode
+
+class WrappedAVLNode<T : Comparable<T>>(private val nodeToWrap: AVLNode<T>) : WrappedNode<T, WrappedAVLNode<T>> {
+    override val data get() = nodeToWrap.data
+    override val parent get() = nodeToWrap.parent?.let { WrappedAVLNode(it) }
+    override val left get() = nodeToWrap.left?.let { WrappedAVLNode(it) }
+    override val right get() = nodeToWrap.right?.let { WrappedAVLNode(it) }
+    val height get() = nodeToWrap.height
+}

--- a/lib/src/main/kotlin/bstrees/wrapped/WrappedNode.kt
+++ b/lib/src/main/kotlin/bstrees/wrapped/WrappedNode.kt
@@ -1,0 +1,8 @@
+package bstrees.wrapped
+
+interface WrappedNode<T : Comparable<T>, WrappedNodeType : WrappedNode<T, WrappedNodeType>> {
+    val data: T
+    val parent: WrappedNodeType?
+    val left: WrappedNodeType?
+    val right: WrappedNodeType?
+}

--- a/lib/src/main/kotlin/bstrees/wrapped/WrappedRBNode.kt
+++ b/lib/src/main/kotlin/bstrees/wrapped/WrappedRBNode.kt
@@ -1,0 +1,11 @@
+package bstrees.wrapped
+
+import bstrees.nodes.RBNode
+
+class WrappedRBNode<T : Comparable<T>>(private val nodeToWrap: RBNode<T>) : WrappedNode<T, WrappedRBNode<T>> {
+    override val data get() = nodeToWrap.data
+    override val parent get() = nodeToWrap.parent?.let { WrappedRBNode(it) }
+    override val left get() = nodeToWrap.left?.let { WrappedRBNode(it) }
+    override val right get() = nodeToWrap.right?.let { WrappedRBNode(it) }
+    val color get() = nodeToWrap.color
+}

--- a/lib/src/main/kotlin/bstrees/wrapped/WrappedSimpleNode.kt
+++ b/lib/src/main/kotlin/bstrees/wrapped/WrappedSimpleNode.kt
@@ -1,0 +1,10 @@
+package bstrees.wrapped
+
+import bstrees.nodes.SimpleNode
+
+class WrappedSimpleNode<T : Comparable<T>>(private val nodeToWrap: SimpleNode<T>) : WrappedNode<T, WrappedSimpleNode<T>> {
+    override val data get() = nodeToWrap.data
+    override val parent get() = nodeToWrap.parent?.let { WrappedSimpleNode(it) }
+    override val left get() = nodeToWrap.left?.let { WrappedSimpleNode(it) }
+    override val right get() = nodeToWrap.right?.let { WrappedSimpleNode(it) }
+}


### PR DESCRIPTION
Add read-only public access to treeRoot for our trees. Now we can traverse tree and check data in nodes.