### PR TITLE
Removed some properties from wrapped nodes

### DIFF
--- a/lib/src/main/kotlin/bstrees/AbstractBSTrees.kt
+++ b/lib/src/main/kotlin/bstrees/AbstractBSTrees.kt
@@ -4,9 +4,9 @@ import bstrees.nodes.TreeNode
 import bstrees.balancers.TreeBalancer
 import bstrees.wrapped.WrappedNode
 
-abstract class BinarySearchTree<T : Comparable<T>, NodeType : TreeNode<T, NodeType>, WrappedNodeType : WrappedNode<T, WrappedNodeType>> {
+abstract class BinarySearchTree<T : Comparable<T>, NodeType : TreeNode<T, NodeType>, WrappedType : WrappedNode<T, WrappedType>> {
     protected var treeRoot: NodeType? = null
-    abstract val root: WrappedNodeType?
+    abstract val root: WrappedType?
 
     fun search(data: T): T? = searchNode(data)?.data
 
@@ -73,7 +73,7 @@ abstract class BinarySearchTree<T : Comparable<T>, NodeType : TreeNode<T, NodeTy
     abstract fun delete(data: T): T?
 }
 
-abstract class SelfBalancingBST<T : Comparable<T>, NodeType : TreeNode<T, NodeType>, WrappedNodeType : WrappedNode<T, WrappedNodeType>> :
-    BinarySearchTree<T, NodeType, WrappedNodeType>() {
+abstract class SelfBalancingBST<T : Comparable<T>, NodeType : TreeNode<T, NodeType>, WrappedType : WrappedNode<T, WrappedType>> :
+    BinarySearchTree<T, NodeType, WrappedType>() {
     protected abstract val balancer: TreeBalancer<T, NodeType>
 }

--- a/lib/src/main/kotlin/bstrees/wrapped/WrappedAVLNode.kt
+++ b/lib/src/main/kotlin/bstrees/wrapped/WrappedAVLNode.kt
@@ -2,7 +2,8 @@ package bstrees.wrapped
 
 import bstrees.nodes.AVLNode
 
-class WrappedAVLNode<T : Comparable<T>>(private val nodeToWrap: AVLNode<T>) : WrappedNode<T, WrappedAVLNode<T>> {
+class WrappedAVLNode<T : Comparable<T>>(private val nodeToWrap: AVLNode<T>) :
+    WrappedNode<T, WrappedAVLNode<T>> {
     override val data get() = nodeToWrap.data
     override val left get() = nodeToWrap.left?.let { WrappedAVLNode(it) }
     override val right get() = nodeToWrap.right?.let { WrappedAVLNode(it) }

--- a/lib/src/main/kotlin/bstrees/wrapped/WrappedAVLNode.kt
+++ b/lib/src/main/kotlin/bstrees/wrapped/WrappedAVLNode.kt
@@ -6,5 +6,4 @@ class WrappedAVLNode<T : Comparable<T>>(private val nodeToWrap: AVLNode<T>) : Wr
     override val data get() = nodeToWrap.data
     override val left get() = nodeToWrap.left?.let { WrappedAVLNode(it) }
     override val right get() = nodeToWrap.right?.let { WrappedAVLNode(it) }
-    val height get() = nodeToWrap.height
 }

--- a/lib/src/main/kotlin/bstrees/wrapped/WrappedAVLNode.kt
+++ b/lib/src/main/kotlin/bstrees/wrapped/WrappedAVLNode.kt
@@ -4,7 +4,6 @@ import bstrees.nodes.AVLNode
 
 class WrappedAVLNode<T : Comparable<T>>(private val nodeToWrap: AVLNode<T>) : WrappedNode<T, WrappedAVLNode<T>> {
     override val data get() = nodeToWrap.data
-    override val parent get() = nodeToWrap.parent?.let { WrappedAVLNode(it) }
     override val left get() = nodeToWrap.left?.let { WrappedAVLNode(it) }
     override val right get() = nodeToWrap.right?.let { WrappedAVLNode(it) }
     val height get() = nodeToWrap.height

--- a/lib/src/main/kotlin/bstrees/wrapped/WrappedNode.kt
+++ b/lib/src/main/kotlin/bstrees/wrapped/WrappedNode.kt
@@ -1,7 +1,7 @@
 package bstrees.wrapped
 
-interface WrappedNode<T : Comparable<T>, WrappedNodeType : WrappedNode<T, WrappedNodeType>> {
+interface WrappedNode<T : Comparable<T>, WrappedType : WrappedNode<T, WrappedType>> {
     val data: T
-    val left: WrappedNodeType?
-    val right: WrappedNodeType?
+    val left: WrappedType?
+    val right: WrappedType?
 }

--- a/lib/src/main/kotlin/bstrees/wrapped/WrappedNode.kt
+++ b/lib/src/main/kotlin/bstrees/wrapped/WrappedNode.kt
@@ -2,7 +2,6 @@ package bstrees.wrapped
 
 interface WrappedNode<T : Comparable<T>, WrappedNodeType : WrappedNode<T, WrappedNodeType>> {
     val data: T
-    val parent: WrappedNodeType?
     val left: WrappedNodeType?
     val right: WrappedNodeType?
 }

--- a/lib/src/main/kotlin/bstrees/wrapped/WrappedRBNode.kt
+++ b/lib/src/main/kotlin/bstrees/wrapped/WrappedRBNode.kt
@@ -4,7 +4,6 @@ import bstrees.nodes.RBNode
 
 class WrappedRBNode<T : Comparable<T>>(private val nodeToWrap: RBNode<T>) : WrappedNode<T, WrappedRBNode<T>> {
     override val data get() = nodeToWrap.data
-    override val parent get() = nodeToWrap.parent?.let { WrappedRBNode(it) }
     override val left get() = nodeToWrap.left?.let { WrappedRBNode(it) }
     override val right get() = nodeToWrap.right?.let { WrappedRBNode(it) }
     val color get() = nodeToWrap.color

--- a/lib/src/main/kotlin/bstrees/wrapped/WrappedRBNode.kt
+++ b/lib/src/main/kotlin/bstrees/wrapped/WrappedRBNode.kt
@@ -2,7 +2,8 @@ package bstrees.wrapped
 
 import bstrees.nodes.RBNode
 
-class WrappedRBNode<T : Comparable<T>>(private val nodeToWrap: RBNode<T>) : WrappedNode<T, WrappedRBNode<T>> {
+class WrappedRBNode<T : Comparable<T>>(private val nodeToWrap: RBNode<T>) :
+    WrappedNode<T, WrappedRBNode<T>> {
     override val data get() = nodeToWrap.data
     override val left get() = nodeToWrap.left?.let { WrappedRBNode(it) }
     override val right get() = nodeToWrap.right?.let { WrappedRBNode(it) }

--- a/lib/src/main/kotlin/bstrees/wrapped/WrappedSimpleNode.kt
+++ b/lib/src/main/kotlin/bstrees/wrapped/WrappedSimpleNode.kt
@@ -4,7 +4,6 @@ import bstrees.nodes.SimpleNode
 
 class WrappedSimpleNode<T : Comparable<T>>(private val nodeToWrap: SimpleNode<T>) : WrappedNode<T, WrappedSimpleNode<T>> {
     override val data get() = nodeToWrap.data
-    override val parent get() = nodeToWrap.parent?.let { WrappedSimpleNode(it) }
     override val left get() = nodeToWrap.left?.let { WrappedSimpleNode(it) }
     override val right get() = nodeToWrap.right?.let { WrappedSimpleNode(it) }
 }

--- a/lib/src/main/kotlin/bstrees/wrapped/WrappedSimpleNode.kt
+++ b/lib/src/main/kotlin/bstrees/wrapped/WrappedSimpleNode.kt
@@ -2,7 +2,8 @@ package bstrees.wrapped
 
 import bstrees.nodes.SimpleNode
 
-class WrappedSimpleNode<T : Comparable<T>>(private val nodeToWrap: SimpleNode<T>) : WrappedNode<T, WrappedSimpleNode<T>> {
+class WrappedSimpleNode<T : Comparable<T>>(private val nodeToWrap: SimpleNode<T>) :
+    WrappedNode<T, WrappedSimpleNode<T>> {
     override val data get() = nodeToWrap.data
     override val left get() = nodeToWrap.left?.let { WrappedSimpleNode(it) }
     override val right get() = nodeToWrap.right?.let { WrappedSimpleNode(it) }


### PR DESCRIPTION
1. Removed `parent` property from all wrapped nodes
2. Removed `height` property from wrapped avl node

`parent` and `height` can be considered internal implementations and should not be accessed from the outside