### PR TITLE
Fix the return value of the 'delete' method in SimpleBST

### DIFF
--- a/lib/src/main/kotlin/bstrees/SimpleBST.kt
+++ b/lib/src/main/kotlin/bstrees/SimpleBST.kt
@@ -11,6 +11,7 @@ class SimpleBST<T : Comparable<T>> : BinarySearchTree<T, SimpleNode<T>, WrappedS
     /** Deletes node and returns its data as a result (or null). */
     override fun delete(data: T): T? {
         val nodeToDelete = searchNode(data) ?: return null
+        val deletedData = nodeToDelete.data
 
         when {
             nodeToDelete.left == null && nodeToDelete.right == null ->
@@ -22,7 +23,7 @@ class SimpleBST<T : Comparable<T>> : BinarySearchTree<T, SimpleNode<T>, WrappedS
             else -> deleteNodeWithTwoChildren(nodeToDelete)
         }
 
-        return nodeToDelete.data
+        return deletedData
     }
 
     /** The node to be deleted is a leaf node */


### PR DESCRIPTION
- Previous ``delete`` realization did not return the value of a node that was removed from a SimpleBST. Added a ``deletedData`` variable which contains data of a node to be deleted. 
- This is recreated PR #15 