### PR TITLE
Fix return value in "insertNode" method if node already exists

### DIFF
--- a/lib/src/main/kotlin/bstrees/AVLTree.kt
+++ b/lib/src/main/kotlin/bstrees/AVLTree.kt
@@ -9,7 +9,7 @@ class AVLTree<T : Comparable<T>> : SelfBalancingBST<T, AVLNode<T>>() {
 
     /** Inserts new node with [data] as its value in the tree */
     override fun insert(data: T) {
-        val insertedNode = insertNode(data)
+        val insertedNode = insertNode(data) ?: return
         root = balancer.balanceAfterInsertion(insertedNode)
     }
 

--- a/lib/src/main/kotlin/bstrees/AbstractBSTrees.kt
+++ b/lib/src/main/kotlin/bstrees/AbstractBSTrees.kt
@@ -32,10 +32,11 @@ abstract class BinarySearchTree<T : Comparable<T>, NodeType : TreeNode<T, NodeTy
     protected abstract fun createNewNode(data: T): NodeType
 
     /**
-     * Does simple insert and returns inserted node
+     * Does simple insert and returns inserted node.
+     * Returns null if the node to insert already exists.
      * Uses [createNewNode] to create new node to insert
      */
-    protected fun insertNode(data: T): NodeType {
+    protected fun insertNode(data: T): NodeType? {
 
         if (root == null) {
             val createdNode = createNewNode(data)
@@ -64,7 +65,7 @@ abstract class BinarySearchTree<T : Comparable<T>, NodeType : TreeNode<T, NodeTy
                 currentNode = currentNode.right!!
             } else {
                 currentNode.data = data
-                return currentNode
+                return null
             }
         }
     }

--- a/lib/src/main/kotlin/bstrees/AbstractBSTrees.kt
+++ b/lib/src/main/kotlin/bstrees/AbstractBSTrees.kt
@@ -33,7 +33,7 @@ abstract class BinarySearchTree<T : Comparable<T>, NodeType : TreeNode<T, NodeTy
 
     /**
      * Does simple insert and returns inserted node.
-     * Returns null if the node to insert already exists.
+     * Returns null and overwrites the data if a node with that data already exists.
      * Uses [createNewNode] to create new node to insert
      */
     protected fun insertNode(data: T): NodeType? {

--- a/lib/src/main/kotlin/bstrees/RBTree.kt
+++ b/lib/src/main/kotlin/bstrees/RBTree.kt
@@ -9,7 +9,7 @@ class RBTree<T : Comparable<T>> : SelfBalancingBST<T, RBNode<T>>() {
 
     /** Inserts a new node with [data] as its value in the tree */
     override fun insert(data: T) {
-        // inserts like in SimpleBST and paints the new Node red
+        // insert like in SimpleBST and paint the new Node red
         val currentNode = insertNode(data) ?: return
         currentNode.flipColor()
         root = balancer.balanceAfterInsertion(currentNode)

--- a/lib/src/main/kotlin/bstrees/RBTree.kt
+++ b/lib/src/main/kotlin/bstrees/RBTree.kt
@@ -7,10 +7,10 @@ class RBTree<T : Comparable<T>> : SelfBalancingBST<T, RBNode<T>>() {
     override fun createNewNode(data: T) = RBNode(data)
     override val balancer = RBBalancer<T>()
 
-    /** Inserts new node with [data] as its value in the tree */
+    /** Inserts a new node with [data] as its value in the tree */
     override fun insert(data: T) {
-        // insert like in SimpleBST and paint the new Node red
-        val currentNode = insertNode(data)
+        // inserts like in SimpleBST and paints the new Node red
+        val currentNode = insertNode(data) ?: return
         currentNode.flipColor()
         root = balancer.balanceAfterInsertion(currentNode)
     }


### PR DESCRIPTION
The previous realization of ``insertNode`` incorrectly handled the case when there is already a node in the tree. 
The return type was changed to nullable to indicate that the node exists by returning a null insted of already existing node.