### PR TITLE
Implement repository pattern to save & restore trees to/from .json files

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
-    id("org.jetbrains.kotlin.jvm") version "1.8.10"
+    kotlin("jvm") version "1.8.20"
+    kotlin("plugin.serialization") version "1.8.20"
     `java-library`
 }
 
@@ -8,6 +9,8 @@ repositories {
 }
 
 dependencies {
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.0")
+
     testImplementation(platform("org.junit:junit-bom:5.9.2"))
     testImplementation("org.junit.jupiter:junit-jupiter")
 }

--- a/lib/src/main/kotlin/bstrees/repos/JsonRepository.kt
+++ b/lib/src/main/kotlin/bstrees/repos/JsonRepository.kt
@@ -1,0 +1,99 @@
+package bstrees.repos
+
+import bstrees.BinarySearchTree
+import bstrees.nodes.TreeNode
+import bstrees.repos.strategies.SerializationStrategy
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import java.io.File
+import java.io.FileNotFoundException
+
+
+@Serializable
+private data class JsonNode(
+    val data: String,
+    val metadata: String,
+    val left: JsonNode?,
+    val right: JsonNode?
+)
+
+@Serializable
+private data class JsonTree(
+    val name: String,
+    val root: JsonNode?
+)
+
+
+/**
+ * Saves binary search trees as .json files in provided [dirPath].
+ * Acts like associative array with trees' names as keys and trees as values.
+ *
+ * Must be provided with [strategy] so repository knows how to work with specific [TreeType].
+ *
+ * Different tree types can be saved in the same [dirPath]
+ * by creating several JsonRepositories with same [dirPath].
+ * Note that saving trees with same tree type but different data type [T]
+ * in the same [dirPath] is error-prone and is not advised.
+ */
+class JsonRepository<T : Comparable<T>,
+        NodeType : TreeNode<T, NodeType>,
+        TreeType : BinarySearchTree<T, NodeType>>(
+    private val strategy: SerializationStrategy<T, NodeType, TreeType>, dirPath: String
+) : TreeRepository<TreeType> {
+    private val dirPath = "$dirPath/${strategy.bstType.toString().lowercase()}"
+
+    // uses hash codes of trees' names as filenames
+    // as storing files with arbitrary unicode names can be error-prone
+
+    override fun getNames(): List<String> =
+        File(dirPath).listFiles()?.map {
+            Json.decodeFromString<JsonTree>(it.readText()).name
+        } ?: listOf()
+
+    override fun get(treeName: String): TreeType? {
+        val json = try {
+            File(dirPath, "${treeName.hashCode()}.json").readText()
+        } catch (_: FileNotFoundException) {
+            return null
+        }
+
+        val jsonTree = Json.decodeFromString<JsonTree>(json)
+        return strategy.createTree().apply {
+            root = jsonTree.root?.deserialize()
+        }
+    }
+
+    override fun set(treeName: String, tree: TreeType) {
+        val jsonTree = JsonTree(treeName, tree.root?.toJsonNode())
+
+        File(dirPath).mkdirs()
+        File(dirPath, "${treeName.hashCode()}.json").run {
+            createNewFile()
+            writeText(Json.encodeToString(jsonTree))
+        }
+    }
+
+    override fun remove(treeName: String): Boolean =
+        File(dirPath, "${treeName.hashCode()}.json").delete()
+
+
+    private fun NodeType.toJsonNode(): JsonNode = JsonNode(
+        data = strategy.collectData(this),
+        metadata = strategy.collectMetadata(this),
+        left = left?.toJsonNode(),
+        right = right?.toJsonNode()
+    )
+
+    private fun JsonNode.deserialize(parent: NodeType? = null): NodeType {
+        val node = strategy.createNode(data)
+        strategy.processMetadata(node, metadata)
+
+        node.parent = parent
+        node.left = left?.deserialize(node)
+        node.right = right?.deserialize(node)
+
+        return node
+    }
+}

--- a/lib/src/main/kotlin/bstrees/repos/TreeRepository.kt
+++ b/lib/src/main/kotlin/bstrees/repos/TreeRepository.kt
@@ -1,0 +1,23 @@
+package bstrees.repos
+
+import bstrees.BinarySearchTree
+
+interface TreeRepository<TreeType : BinarySearchTree<*, *>> {
+    /** Gets the names of all trees in the repository */
+    fun getNames(): List<String>
+
+    /** Gets the tree by its name. Returns null if such tree not found */
+    operator fun get(treeName: String): TreeType?
+
+    /**
+     * Adds [tree] to the repository.
+     * If tree with [treeName] already exists replaces it with provided one.
+     */
+    operator fun set(treeName: String, tree: TreeType)
+
+    /**
+     * Removes tree from the repository.
+     * Returns false if tree with [treeName] not found.
+     */
+    fun remove(treeName: String): Boolean
+}

--- a/lib/src/main/kotlin/bstrees/repos/strategies/AVLStrategy.kt
+++ b/lib/src/main/kotlin/bstrees/repos/strategies/AVLStrategy.kt
@@ -1,0 +1,25 @@
+package bstrees.repos.strategies
+
+import bstrees.AVLTree
+import bstrees.nodes.AVLNode
+
+/**
+ * Used to serialize and deserialize [AVLTree].
+ *
+ * To serialize and deserialize tree's data type [T]
+ * strategy must be provided with corresponding functions.
+ */
+class AVLStrategy<T : Comparable<T>>(
+    serializeData: (T) -> String, deserializeData: (String) -> T
+) : SerializationStrategy<T, AVLNode<T>, AVLTree<T>>(serializeData, deserializeData) {
+    override val bstType = BSTType.AVL
+
+    override fun createNode(data: T) = AVLNode(data)
+    override fun createTree() = AVLTree<T>()
+
+    override fun collectMetadata(node: AVLNode<T>) = node.height.toString()
+    override fun processMetadata(node: AVLNode<T>, metadata: String) {
+        node.height = metadata.toIntOrNull()
+            ?: throw IllegalArgumentException("Metadata must contain node's height")
+    }
+}

--- a/lib/src/main/kotlin/bstrees/repos/strategies/RBStrategy.kt
+++ b/lib/src/main/kotlin/bstrees/repos/strategies/RBStrategy.kt
@@ -1,0 +1,29 @@
+package bstrees.repos.strategies
+
+import bstrees.RBTree
+import bstrees.nodes.RBNode
+
+/**
+ * Used to serialize and deserialize [RBTree].
+ *
+ * To serialize and deserialize tree's data type [T]
+ * strategy must be provided with corresponding functions.
+ */
+class RBStrategy<T : Comparable<T>>(
+    serializeData: (T) -> String, deserializeData: (String) -> T
+) : SerializationStrategy<T, RBNode<T>, RBTree<T>>(serializeData, deserializeData) {
+    override val bstType = BSTType.RB
+
+    override fun createNode(data: T) = RBNode(data)
+    override fun createTree() = RBTree<T>()
+
+    override fun collectMetadata(node: RBNode<T>) = node.color.toString().first().toString()
+    override fun processMetadata(node: RBNode<T>, metadata: String) {
+        when (metadata) {
+            "R" -> node.color = RBNode.Color.Red
+            "B" -> node.color = RBNode.Color.Black
+            else -> throw IllegalArgumentException("Metadata must contain node's color")
+        }
+    }
+}
+

--- a/lib/src/main/kotlin/bstrees/repos/strategies/SerializationStrategy.kt
+++ b/lib/src/main/kotlin/bstrees/repos/strategies/SerializationStrategy.kt
@@ -1,0 +1,27 @@
+package bstrees.repos.strategies
+
+import bstrees.BinarySearchTree
+import bstrees.nodes.TreeNode
+
+enum class BSTType {
+    Simple,
+    AVL,
+    RB
+}
+
+abstract class SerializationStrategy<T : Comparable<T>,
+        NodeType : TreeNode<T, NodeType>,
+        TreeType : BinarySearchTree<T, NodeType>>(
+    private val serializeData: (T) -> String,
+    private val deserializeData: (String) -> T
+) {
+    abstract val bstType: BSTType
+
+    fun createNode(data: String): NodeType = createNode(deserializeData(data))
+    protected abstract fun createNode(data: T): NodeType
+    abstract fun createTree(): TreeType
+
+    fun collectData(node: NodeType): String = serializeData(node.data)
+    abstract fun collectMetadata(node: NodeType): String
+    abstract fun processMetadata(node: NodeType, metadata: String)
+}

--- a/lib/src/main/kotlin/bstrees/repos/strategies/SimpleStrategy.kt
+++ b/lib/src/main/kotlin/bstrees/repos/strategies/SimpleStrategy.kt
@@ -1,0 +1,22 @@
+package bstrees.repos.strategies
+
+import bstrees.SimpleBST
+import bstrees.nodes.SimpleNode
+
+/**
+ * Used to serialize and deserialize [SimpleBST].
+ *
+ * To serialize and deserialize tree's data type [T]
+ * strategy must be provided with corresponding functions.
+ */
+class SimpleStrategy<T : Comparable<T>>(
+    serializeData: (T) -> String, deserializeData: (String) -> T
+) : SerializationStrategy<T, SimpleNode<T>, SimpleBST<T>>(serializeData, deserializeData) {
+    override val bstType = BSTType.Simple
+
+    override fun createTree() = SimpleBST<T>()
+    override fun createNode(data: T) = SimpleNode(data)
+
+    override fun collectMetadata(node: SimpleNode<T>) = ""
+    override fun processMetadata(node: SimpleNode<T>, metadata: String) {}
+}


### PR DESCRIPTION
- Add `TreeRepository` interface to describe arbitrary repository holding any type of tree
- Add `JsonRepository` implementing `TreeRepository`. `JsonRepository` stores trees in .json files.
`JsonRepository` accepts `SerializationStrategy` that tells repository how to work with specific tree types
- Implement `SerializationStrategy` for `AVLTree`, `RBTree`, `SimpleBST`