### PR TITLE
refactor(TreeBalancer): move rotate realization

### DIFF
--- a/lib/src/main/kotlin/bstrees/balancers/AVLBalancer.kt
+++ b/lib/src/main/kotlin/bstrees/balancers/AVLBalancer.kt
@@ -3,7 +3,7 @@ package bstrees.balancers
 import bstrees.nodes.AVLNode
 import kotlin.math.max
 
-internal class AVLBalancer<T : Comparable<T>> : TreeBalancer<T, AVLNode<T>> {
+internal class AVLBalancer<T : Comparable<T>> : TreeBalancer<T, AVLNode<T>>() {
     /**
      * Rotates right edge of the [node] counterclockwise.
      * Returns node that will be in place of the [node] passed
@@ -11,23 +11,11 @@ internal class AVLBalancer<T : Comparable<T>> : TreeBalancer<T, AVLNode<T>> {
      * Calls [updateHeight] to update heights of the nodes affected.
      * Throws [IllegalArgumentException] if [node] without right child is passed
      */
-    private fun rotateLeft(node: AVLNode<T>): AVLNode<T> {
-        val rightChild = node.right
-            ?: throw IllegalArgumentException("Node to rotate must have a right child")
-
-        rightChild.parent = node.parent
-        if (node.parent?.left == node) node.parent?.left = rightChild
-        else node.parent?.right = rightChild
-
-        node.right = rightChild.left
-        rightChild.left?.parent = node
-
-        rightChild.left = node
-        node.parent = rightChild
-
+    override fun rotateLeft(node: AVLNode<T>): AVLNode<T> {
+        val newRoot = super.rotateLeft(node)
         updateHeight(node)
-        updateHeight(rightChild)
-        return rightChild
+        updateHeight(newRoot)
+        return newRoot
     }
 
     /**
@@ -37,23 +25,11 @@ internal class AVLBalancer<T : Comparable<T>> : TreeBalancer<T, AVLNode<T>> {
      * Calls [updateHeight] to update heights of the nodes affected.
      * Throws [IllegalArgumentException] if [node] without left child is passed
      */
-    private fun rotateRight(node: AVLNode<T>): AVLNode<T> {
-        val leftChild = node.left
-            ?: throw IllegalArgumentException("Node to rotate must have a left child")
-
-        leftChild.parent = node.parent
-        if (node.parent?.left == node) node.parent?.left = leftChild
-        else node.parent?.right = leftChild
-
-        node.left = leftChild.right
-        leftChild.right?.parent = node
-
-        leftChild.right = node
-        node.parent = leftChild
-
+    override fun rotateRight(node: AVLNode<T>): AVLNode<T> {
+        val newRoot = super.rotateRight(node)
         updateHeight(node)
-        updateHeight(leftChild)
-        return leftChild
+        updateHeight(newRoot)
+        return newRoot
     }
 
     /** Returns height of the [node] in AVL tree. Returns 0 if null passed */

--- a/lib/src/main/kotlin/bstrees/balancers/RBBalancer.kt
+++ b/lib/src/main/kotlin/bstrees/balancers/RBBalancer.kt
@@ -2,7 +2,7 @@ package bstrees.balancers
 
 import bstrees.nodes.RBNode
 
-internal class RBBalancer<T : Comparable<T>> : TreeBalancer<T, RBNode<T>> {
+internal class RBBalancer<T : Comparable<T>> : TreeBalancer<T, RBNode<T>>() {
     private fun getColor(node: RBNode<T>?) = node?.color ?: RBNode.Color.Black
 
     private fun isRed(node: RBNode<T>?) = getColor(node) == RBNode.Color.Red
@@ -18,36 +18,6 @@ internal class RBBalancer<T : Comparable<T>> : TreeBalancer<T, RBNode<T>> {
     private fun getUncle(node: RBNode<T>): RBNode<T>? {
         val parent = node.parent ?: return null
         return getSibling(parent)
-    }
-
-    private fun rotateRight(node: RBNode<T>): RBNode<T> {
-        val parent = node.parent
-        val wasChild = node.left
-            ?: throw IllegalArgumentException("Node to rotate must have a left child")
-        node.left = wasChild.right
-        wasChild.right = node
-        node.left?.parent = node
-        node.parent = wasChild
-
-        if (parent?.left == node) parent.left = wasChild else parent?.right = wasChild
-        wasChild.parent = parent
-
-        return wasChild
-    }
-
-    private fun rotateLeft(node: RBNode<T>): RBNode<T> {
-        val parent = node.parent
-        val wasChild = node.right
-            ?: throw IllegalArgumentException("Node to rotate must have a right child")
-        node.right = wasChild.left
-        wasChild.left = node
-        node.right?.parent = node
-        node.parent = wasChild
-
-        if (parent?.left == node) parent.left = wasChild else parent?.right = wasChild
-        wasChild.parent = parent
-
-        return wasChild
     }
 
     /** Accepts the inserted node. Returns new tree root */

--- a/lib/src/main/kotlin/bstrees/balancers/TreeBalancer.kt
+++ b/lib/src/main/kotlin/bstrees/balancers/TreeBalancer.kt
@@ -2,7 +2,53 @@ package bstrees.balancers
 
 import bstrees.nodes.TreeNode
 
-internal interface TreeBalancer<T : Comparable<T>, NodeType : TreeNode<T, NodeType>> {
-    fun balanceAfterInsertion(node: NodeType): NodeType
-    fun balanceAfterDeletion(node: NodeType): NodeType
+internal abstract class TreeBalancer<T : Comparable<T>, NodeType : TreeNode<T, NodeType>> {
+    abstract fun balanceAfterInsertion(node: NodeType): NodeType
+    abstract fun balanceAfterDeletion(node: NodeType): NodeType
+
+    /**
+     * Rotates right edge of the [node] counterclockwise.
+     * Returns node that will be in place of the [node] passed
+     *
+     * Throws [IllegalArgumentException] if [node] without right child is passed
+     */
+    protected open fun rotateLeft(node: NodeType): NodeType {
+        val rightChild = node.right
+            ?: throw IllegalArgumentException("Node to rotate must have a right child")
+
+        rightChild.parent = node.parent
+        if (node.parent?.left == node) node.parent?.left = rightChild
+        else node.parent?.right = rightChild
+
+        node.right = rightChild.left
+        rightChild.left?.parent = node
+
+        rightChild.left = node
+        node.parent = rightChild
+
+        return rightChild
+    }
+
+    /**
+     * Rotates left edge of the [node] clockwise.
+     * Returns node that will be in place of the [node] passed
+     *
+     * Throws [IllegalArgumentException] if [node] without left child is passed
+     */
+    protected open fun rotateRight(node: NodeType): NodeType {
+        val leftChild = node.left
+            ?: throw IllegalArgumentException("Node to rotate must have a left child")
+
+        leftChild.parent = node.parent
+        if (node.parent?.left == node) node.parent?.left = leftChild
+        else node.parent?.right = leftChild
+
+        node.left = leftChild.right
+        leftChild.right?.parent = node
+
+        leftChild.right = node
+        node.parent = leftChild
+
+        return leftChild
+    }
 }


### PR DESCRIPTION
Moved ``rotateRight`` and ``rotateLeft``to ``TreeBalancer`` interface to avoid duplicate code. 
Overrided those methods in ``AVLBalancer`` to update heights.