### PR TITLE
Refactor: rename and move functions

### DIFF
--- a/lib/src/main/kotlin/bstrees/AbstractBSTrees.kt
+++ b/lib/src/main/kotlin/bstrees/AbstractBSTrees.kt
@@ -99,30 +99,41 @@ abstract class BinarySearchTree<T : Comparable<T>, NodeType : TreeNode<T, NodeTy
         }
     }
 
+    /** Replaces the child of the parent of the [wasChild] to [newChild] */
+    protected fun replaceChild(wasChild: NodeType, newChild: NodeType?) {
+        val parent = wasChild.parent
+        if (parent == null) {
+            root = newChild
+        } else if (parent.left == wasChild) {
+            parent.left = newChild
+        } else {
+            parent.right = newChild
+        }
+
+        newChild?.parent = wasChild.parent
+    }
+
+    /** Searches for node's in-order predecessor */
+    protected fun findPredecessor(node: NodeType): NodeType {
+        var nodeToReplaceWith = node.left
+            ?: throw IllegalStateException("node must have two children")
+        while (nodeToReplaceWith.right != null) {
+            nodeToReplaceWith = nodeToReplaceWith.right
+                ?: throw IllegalStateException("nodeToReplaceWith must have right child")
+        }
+        return nodeToReplaceWith
+    }
+
     /** The node to be deleted is a leaf node. Returns deleted node */
     private fun deleteLeafNode(node: NodeType): NodeType {
-        val parent = node.parent
-        if (parent != null) {
-            if (parent.right == node) parent.right = null
-            else parent.left = null
-        } else root = null
+        replaceChild(node, null)
         return node
     }
 
     /** The node to be deleted has only one child. Returns deleted node */
     private fun deleteNodeWithOneChild(node: NodeType): NodeType {
-        val parent = node.parent
-
-        if (parent == null) {
-            root = node.left ?: node.right
-            root?.parent = null
-        } else {
-            val nodeToReplaceWith = if (node.left == null) node.right else node.left
-            if (parent.right == node) parent.right = nodeToReplaceWith
-            else parent.left = nodeToReplaceWith
-
-            nodeToReplaceWith?.parent = parent
-        }
+        val nodeToReplaceWith = if (node.left == null) node.right else node.left
+        replaceChild(node, nodeToReplaceWith)
         return node
     }
 
@@ -132,16 +143,10 @@ abstract class BinarySearchTree<T : Comparable<T>, NodeType : TreeNode<T, NodeTy
      * Returns node that was actually deleted
      */
     private fun deleteNodeWithTwoChildren(node: NodeType): NodeType {
-        // find in-order predecessor
-        var nodeToReplaceWith = node.left
-            ?: throw IllegalStateException("node must have two children")
-        while (nodeToReplaceWith.right != null)
-            nodeToReplaceWith = nodeToReplaceWith.right
-                ?: throw IllegalStateException("nodeToReplaceWith must have right child")
-
+        val nodePredecessor =  findPredecessor(node)
         // replace data and delete predecessor
-        node.data = nodeToReplaceWith.data
-        return deleteNode(nodeToReplaceWith)
+        node.data = nodePredecessor.data
+        return deleteNode(nodePredecessor)
     }
 
 }

--- a/lib/src/main/kotlin/bstrees/RBTree.kt
+++ b/lib/src/main/kotlin/bstrees/RBTree.kt
@@ -2,6 +2,8 @@ package bstrees
 
 import bstrees.nodes.RBNode
 import bstrees.balancers.RBBalancer
+import bstrees.nodes.RBNode.Color.Red
+import bstrees.nodes.RBNode.Color.Black
 
 class RBTree<T : Comparable<T>> : SelfBalancingBST<T, RBNode<T>>() {
     override fun createNewNode(data: T) = RBNode(data)
@@ -10,7 +12,7 @@ class RBTree<T : Comparable<T>> : SelfBalancingBST<T, RBNode<T>>() {
     override fun insert(data: T) {
         // insert like in SimpleBST and paint the new Node red
         val currentNode = insertNode(data) ?: return
-        currentNode.flipColor()
+        currentNode.color = Red
         root = balancer.balanceAfterInsertion(currentNode)
     }
 
@@ -19,62 +21,36 @@ class RBTree<T : Comparable<T>> : SelfBalancingBST<T, RBNode<T>>() {
         val result = foundNode.data
 
         val nodeToDelete = if (foundNode.left != null && foundNode.right != null) {
-            val nodeToReplaceWith = findNodeToReplaceWith(foundNode)
+            val nodeToReplaceWith = findPredecessor(foundNode)
             foundNode.data = nodeToReplaceWith.data
             nodeToReplaceWith
         } else {
             foundNode
         }
 
-        fun changeChild(wasChild: RBNode<T>, newChild: RBNode<T>?) {
-            val parent = wasChild.parent
-            if (parent == null) {
-                root = newChild
-            } else if (parent.left == wasChild) {
-                parent.left = newChild
-            } else {
-                parent.right = newChild
-            }
-
-            newChild?.parent = wasChild.parent
-        }
-
         //nodeToDelete has one child or zero
         when {
             // node is the leaf
             nodeToDelete.left == null && nodeToDelete.right == null -> {
-                // update children of the parent of the deleted node
-
-                if (nodeToDelete.color == RBNode.Color.Black) {
+                if (nodeToDelete.color == Black) {
                     root = balancer.balanceAfterDeletion(nodeToDelete)
                 }
-
-                changeChild(nodeToDelete, null)
-
+                replaceChild(nodeToDelete, null)
             }
 
+            // node has only left child
             nodeToDelete.left != null -> {
                 nodeToDelete.left?.flipColor()
-                changeChild(nodeToDelete, nodeToDelete.left)
+                replaceChild(nodeToDelete, nodeToDelete.left)
             }
 
+            // node has only right child
             else -> {
                 nodeToDelete.right?.flipColor()
-                changeChild(nodeToDelete, nodeToDelete.right)
+                replaceChild(nodeToDelete, nodeToDelete.right)
             }
         }
 
         return result
-    }
-
-    /** Searches for node's in-order predecessor */
-    private fun findNodeToReplaceWith(node: RBNode<T>): RBNode<T> {
-        var nodeToReplaceWith = node.left
-            ?: throw IllegalStateException("node must have two children")
-        while (nodeToReplaceWith.right != null) {
-            nodeToReplaceWith = nodeToReplaceWith.right
-                ?: throw IllegalStateException("nodeToReplaceWith must have right child")
-        }
-        return nodeToReplaceWith
     }
 }


### PR DESCRIPTION
Rename and move functions `changeChild`, `findNodeToReplaceWith`. Edit comments 