### PR TITLE
Refactor `bstrees` lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ val tree2 = AVLTree<Int>().apply {
 
 avlIntRepo["my tree"] = tree1
 avlIntRepo["another tree"] = tree2
-avlIntRepo.getNames() // returns ["my tree", "another tree"]
+avlIntRepo.names // returns ["my tree", "another tree"]
 
 avlIntRepo.remove("my tree") // returns true
-avlIntRepo.getNames() // returns ["another tree"]
+avlIntRepo.names // returns ["another tree"]
 
 val restored = avlIntRepo["another tree"] // 'restored' & 'tree2' are the same trees
 ```

--- a/lib/src/main/kotlin/bstrees/AVLTree.kt
+++ b/lib/src/main/kotlin/bstrees/AVLTree.kt
@@ -3,16 +3,16 @@ package bstrees
 import bstrees.nodes.AVLNode
 import bstrees.balancers.AVLBalancer
 
-class AVLTree<T : Comparable<T>> : SelfBalancingBST<T, AVLNode<T>>() {
-    override fun createNewNode(data: T) = AVLNode(data)
-    override val balancer = AVLBalancer<T>()
+class AVLTree<E : Comparable<E>> : SelfBalancingBST<E, AVLNode<E>>() {
+    override fun createNewNode(data: E) = AVLNode(data)
+    override val balancer = AVLBalancer<E>()
 
-    override fun insert(data: T) {
+    override fun insert(data: E) {
         val insertedNode = insertNode(data) ?: return
         root = balancer.balanceAfterInsertion(insertedNode)
     }
 
-    override fun delete(data: T): T? {
+    override fun delete(data: E): E? {
         val node = searchNode(data) ?: return null
         val dataToDelete = node.data
 

--- a/lib/src/main/kotlin/bstrees/AbstractBSTrees.kt
+++ b/lib/src/main/kotlin/bstrees/AbstractBSTrees.kt
@@ -3,15 +3,15 @@ package bstrees
 import bstrees.nodes.TreeNode
 import bstrees.balancers.TreeBalancer
 
-abstract class BinarySearchTree<T : Comparable<T>, NodeType : TreeNode<T, NodeType>> {
-    var root: NodeType? = null
+abstract class BinarySearchTree<E : Comparable<E>, N : TreeNode<E, N>> {
+    var root: N? = null
         internal set
 
     /** Searches [data] in the tree. Returns it if found */
-    fun search(data: T): T? = searchNode(data)?.data
+    fun search(data: E): E? = searchNode(data)?.data
 
     /** Searches for node and returns it as a result (or null) */
-    protected fun searchNode(data: T): NodeType? {
+    protected fun searchNode(data: E): N? {
         var currentNode = root
         while (currentNode != null) {
             val res = data.compareTo(currentNode.data)
@@ -25,18 +25,18 @@ abstract class BinarySearchTree<T : Comparable<T>, NodeType : TreeNode<T, NodeTy
     }
 
     /** Inserts new node in the tree with [data] as its value */
-    open fun insert(data: T) {
+    open fun insert(data: E) {
         insertNode(data)
     }
 
-    protected abstract fun createNewNode(data: T): NodeType
+    protected abstract fun createNewNode(data: E): N
 
     /**
      * Does simple insert and returns inserted node.
      * Returns null and overwrites the data if a node with that data already exists.
      * Uses [createNewNode] to create new node to insert
      */
-    protected fun insertNode(data: T): NodeType? {
+    protected fun insertNode(data: E): N? {
         if (root == null) {
             val createdNode = createNewNode(data)
             root = createdNode
@@ -73,7 +73,7 @@ abstract class BinarySearchTree<T : Comparable<T>, NodeType : TreeNode<T, NodeTy
     }
 
     /** Deletes node with [data] as its value. Returns deleted data */
-    open fun delete(data: T): T? {
+    open fun delete(data: E): E? {
         val node = searchNode(data) ?: return null
         val dataToDelete = node.data
 
@@ -87,7 +87,7 @@ abstract class BinarySearchTree<T : Comparable<T>, NodeType : TreeNode<T, NodeTy
      * Note that returned node is not always the same as [node].
      * Returned node can have different data than [node]
      */
-    protected fun deleteNode(node: NodeType): NodeType {
+    protected fun deleteNode(node: N): N {
         return when {
             node.left == null && node.right == null ->
                 deleteLeafNode(node)
@@ -100,7 +100,7 @@ abstract class BinarySearchTree<T : Comparable<T>, NodeType : TreeNode<T, NodeTy
     }
 
     /** Replaces the child of the parent of the [wasChild] to [newChild] */
-    protected fun replaceChild(wasChild: NodeType, newChild: NodeType?) {
+    protected fun replaceChild(wasChild: N, newChild: N?) {
         val parent = wasChild.parent
         if (parent == null) {
             root = newChild
@@ -114,7 +114,7 @@ abstract class BinarySearchTree<T : Comparable<T>, NodeType : TreeNode<T, NodeTy
     }
 
     /** Searches for node's in-order predecessor */
-    protected fun findPredecessor(node: NodeType): NodeType {
+    protected fun findPredecessor(node: N): N {
         var nodeToReplaceWith = node.left
             ?: throw IllegalStateException("node must have two children")
         while (nodeToReplaceWith.right != null) {
@@ -125,13 +125,13 @@ abstract class BinarySearchTree<T : Comparable<T>, NodeType : TreeNode<T, NodeTy
     }
 
     /** The node to be deleted is a leaf node. Returns deleted node */
-    private fun deleteLeafNode(node: NodeType): NodeType {
+    private fun deleteLeafNode(node: N): N {
         replaceChild(node, null)
         return node
     }
 
     /** The node to be deleted has only one child. Returns deleted node */
-    private fun deleteNodeWithOneChild(node: NodeType): NodeType {
+    private fun deleteNodeWithOneChild(node: N): N {
         val nodeToReplaceWith = if (node.left == null) node.right else node.left
         replaceChild(node, nodeToReplaceWith)
         return node
@@ -142,8 +142,8 @@ abstract class BinarySearchTree<T : Comparable<T>, NodeType : TreeNode<T, NodeTy
      * The node to be deleted has two children.
      * Returns node that was actually deleted
      */
-    private fun deleteNodeWithTwoChildren(node: NodeType): NodeType {
-        val nodePredecessor =  findPredecessor(node)
+    private fun deleteNodeWithTwoChildren(node: N): N {
+        val nodePredecessor = findPredecessor(node)
         // replace data and delete predecessor
         node.data = nodePredecessor.data
         return deleteNode(nodePredecessor)
@@ -151,7 +151,7 @@ abstract class BinarySearchTree<T : Comparable<T>, NodeType : TreeNode<T, NodeTy
 
 }
 
-abstract class SelfBalancingBST<T : Comparable<T>, NodeType : TreeNode<T, NodeType>> :
-    BinarySearchTree<T, NodeType>() {
-    internal abstract val balancer: TreeBalancer<T, NodeType>
+abstract class SelfBalancingBST<E : Comparable<E>, N : TreeNode<E, N>> :
+    BinarySearchTree<E, N>() {
+    internal abstract val balancer: TreeBalancer<E, N>
 }

--- a/lib/src/main/kotlin/bstrees/RBTree.kt
+++ b/lib/src/main/kotlin/bstrees/RBTree.kt
@@ -5,18 +5,18 @@ import bstrees.balancers.RBBalancer
 import bstrees.nodes.RBNode.Color.Red
 import bstrees.nodes.RBNode.Color.Black
 
-class RBTree<T : Comparable<T>> : SelfBalancingBST<T, RBNode<T>>() {
-    override fun createNewNode(data: T) = RBNode(data)
-    override val balancer = RBBalancer<T>()
+class RBTree<E : Comparable<E>> : SelfBalancingBST<E, RBNode<E>>() {
+    override fun createNewNode(data: E) = RBNode(data)
+    override val balancer = RBBalancer<E>()
 
-    override fun insert(data: T) {
+    override fun insert(data: E) {
         // insert like in SimpleBST and paint the new Node red
         val currentNode = insertNode(data) ?: return
         currentNode.color = Red
         root = balancer.balanceAfterInsertion(currentNode)
     }
 
-    override fun delete(data: T): T? {
+    override fun delete(data: E): E? {
         val foundNode = searchNode(data) ?: return null
         val result = foundNode.data
 

--- a/lib/src/main/kotlin/bstrees/SimpleBST.kt
+++ b/lib/src/main/kotlin/bstrees/SimpleBST.kt
@@ -2,6 +2,6 @@ package bstrees
 
 import bstrees.nodes.SimpleNode
 
-class SimpleBST<T : Comparable<T>> : BinarySearchTree<T, SimpleNode<T>>() {
-    override fun createNewNode(data: T) = SimpleNode(data)
+class SimpleBST<E : Comparable<E>> : BinarySearchTree<E, SimpleNode<E>>() {
+    override fun createNewNode(data: E) = SimpleNode(data)
 }

--- a/lib/src/main/kotlin/bstrees/balancers/AVLBalancer.kt
+++ b/lib/src/main/kotlin/bstrees/balancers/AVLBalancer.kt
@@ -3,7 +3,7 @@ package bstrees.balancers
 import bstrees.nodes.AVLNode
 import kotlin.math.max
 
-internal class AVLBalancer<T : Comparable<T>> : TreeBalancer<T, AVLNode<T>>() {
+internal class AVLBalancer<E : Comparable<E>> : TreeBalancer<E, AVLNode<E>>() {
     /**
      * Rotates right edge of the [node] counterclockwise.
      * Returns node that will be in place of the [node] passed
@@ -11,7 +11,7 @@ internal class AVLBalancer<T : Comparable<T>> : TreeBalancer<T, AVLNode<T>>() {
      * Calls [updateHeight] to update heights of the nodes affected.
      * Throws [IllegalArgumentException] if [node] without right child is passed
      */
-    override fun rotateLeft(node: AVLNode<T>): AVLNode<T> {
+    override fun rotateLeft(node: AVLNode<E>): AVLNode<E> {
         val newRoot = super.rotateLeft(node)
         updateHeight(node)
         updateHeight(newRoot)
@@ -25,7 +25,7 @@ internal class AVLBalancer<T : Comparable<T>> : TreeBalancer<T, AVLNode<T>>() {
      * Calls [updateHeight] to update heights of the nodes affected.
      * Throws [IllegalArgumentException] if [node] without left child is passed
      */
-    override fun rotateRight(node: AVLNode<T>): AVLNode<T> {
+    override fun rotateRight(node: AVLNode<E>): AVLNode<E> {
         val newRoot = super.rotateRight(node)
         updateHeight(node)
         updateHeight(newRoot)
@@ -33,15 +33,15 @@ internal class AVLBalancer<T : Comparable<T>> : TreeBalancer<T, AVLNode<T>>() {
     }
 
     /** Returns height of the [node] in AVL tree. Returns 0 if null passed */
-    private fun getHeight(node: AVLNode<T>?) = node?.height ?: 0
+    private fun getHeight(node: AVLNode<E>?) = node?.height ?: 0
 
     /** Updates height of the [node] in AVL tree */
-    private fun updateHeight(node: AVLNode<T>) {
+    private fun updateHeight(node: AVLNode<E>) {
         node.height = max(getHeight(node.left), getHeight(node.right)) + 1
     }
 
     /** Returns balance factor of the [node] in AVL tree */
-    private fun balanceFactor(node: AVLNode<T>) =
+    private fun balanceFactor(node: AVLNode<E>) =
         getHeight(node.left) - getHeight(node.right)
 
     /**
@@ -49,7 +49,7 @@ internal class AVLBalancer<T : Comparable<T>> : TreeBalancer<T, AVLNode<T>>() {
      * Must be called after every insertion with inserted [node] as parameter.
      * Returns new root of the tree
      */
-    override tailrec fun balanceAfterInsertion(node: AVLNode<T>): AVLNode<T> {
+    override tailrec fun balanceAfterInsertion(node: AVLNode<E>): AVLNode<E> {
         var currentNode = node
         when (balanceFactor(currentNode)) {
             // LL or LR
@@ -95,5 +95,5 @@ internal class AVLBalancer<T : Comparable<T>> : TreeBalancer<T, AVLNode<T>>() {
      * Note that deleted node is a node that doesn't belong to the tree.
      * Returns new root of the tree
      */
-    override fun balanceAfterDeletion(node: AVLNode<T>) = balanceAfterInsertion(node)
+    override fun balanceAfterDeletion(node: AVLNode<E>) = balanceAfterInsertion(node)
 }

--- a/lib/src/main/kotlin/bstrees/balancers/RBBalancer.kt
+++ b/lib/src/main/kotlin/bstrees/balancers/RBBalancer.kt
@@ -2,26 +2,26 @@ package bstrees.balancers
 
 import bstrees.nodes.RBNode
 
-internal class RBBalancer<T : Comparable<T>> : TreeBalancer<T, RBNode<T>>() {
-    private fun getColor(node: RBNode<T>?) = node?.color ?: RBNode.Color.Black
+internal class RBBalancer<E : Comparable<E>> : TreeBalancer<E, RBNode<E>>() {
+    private fun getColor(node: RBNode<E>?) = node?.color ?: RBNode.Color.Black
 
-    private fun isRed(node: RBNode<T>?) = getColor(node) == RBNode.Color.Red
+    private fun isRed(node: RBNode<E>?) = getColor(node) == RBNode.Color.Red
 
-    private fun isBlack(node: RBNode<T>?) = !isRed(node)
+    private fun isBlack(node: RBNode<E>?) = !isRed(node)
 
-    private fun getSibling(node: RBNode<T>): RBNode<T>? {
+    private fun getSibling(node: RBNode<E>): RBNode<E>? {
         val parent = node.parent ?: return null
         return if (parent.left == node) parent.right
         else parent.left
     }
 
-    private fun getUncle(node: RBNode<T>): RBNode<T>? {
+    private fun getUncle(node: RBNode<E>): RBNode<E>? {
         val parent = node.parent ?: return null
         return getSibling(parent)
     }
 
     /** Accepts the inserted node. Returns new tree root */
-    override fun balanceAfterInsertion(node: RBNode<T>): RBNode<T> {
+    override fun balanceAfterInsertion(node: RBNode<E>): RBNode<E> {
         var currentNode = node
 
         while (currentNode.parent != null && isRed(currentNode.parent)) {
@@ -72,7 +72,7 @@ internal class RBBalancer<T : Comparable<T>> : TreeBalancer<T, RBNode<T>>() {
      *
      * Doesn't itself delete [node]. Caller must delete the node on their own
      */
-    override fun balanceAfterDeletion(node: RBNode<T>): RBNode<T> {
+    override fun balanceAfterDeletion(node: RBNode<E>): RBNode<E> {
         var currentNode = node
         while (currentNode.parent != null && isBlack(currentNode)) {
             val parent = currentNode.parent

--- a/lib/src/main/kotlin/bstrees/balancers/TreeBalancer.kt
+++ b/lib/src/main/kotlin/bstrees/balancers/TreeBalancer.kt
@@ -2,9 +2,9 @@ package bstrees.balancers
 
 import bstrees.nodes.TreeNode
 
-internal abstract class TreeBalancer<T : Comparable<T>, NodeType : TreeNode<T, NodeType>> {
-    abstract fun balanceAfterInsertion(node: NodeType): NodeType
-    abstract fun balanceAfterDeletion(node: NodeType): NodeType
+internal abstract class TreeBalancer<E : Comparable<E>, N : TreeNode<E, N>> {
+    abstract fun balanceAfterInsertion(node: N): N
+    abstract fun balanceAfterDeletion(node: N): N
 
     /**
      * Rotates right edge of the [node] counterclockwise.
@@ -12,7 +12,7 @@ internal abstract class TreeBalancer<T : Comparable<T>, NodeType : TreeNode<T, N
      *
      * Throws [IllegalArgumentException] if [node] without right child is passed
      */
-    protected open fun rotateLeft(node: NodeType): NodeType {
+    protected open fun rotateLeft(node: N): N {
         val rightChild = node.right
             ?: throw IllegalArgumentException("Node to rotate must have a right child")
 
@@ -35,7 +35,7 @@ internal abstract class TreeBalancer<T : Comparable<T>, NodeType : TreeNode<T, N
      *
      * Throws [IllegalArgumentException] if [node] without left child is passed
      */
-    protected open fun rotateRight(node: NodeType): NodeType {
+    protected open fun rotateRight(node: N): N {
         val leftChild = node.left
             ?: throw IllegalArgumentException("Node to rotate must have a left child")
 

--- a/lib/src/main/kotlin/bstrees/nodes/AVLNode.kt
+++ b/lib/src/main/kotlin/bstrees/nodes/AVLNode.kt
@@ -1,5 +1,5 @@
 package bstrees.nodes
 
-class AVLNode<T : Comparable<T>>(override var data: T) : TreeNode<T, AVLNode<T>>() {
+class AVLNode<T : Comparable<T>>(data: T) : TreeNode<T, AVLNode<T>>(data) {
     internal var height = 1
 }

--- a/lib/src/main/kotlin/bstrees/nodes/AVLNode.kt
+++ b/lib/src/main/kotlin/bstrees/nodes/AVLNode.kt
@@ -1,5 +1,5 @@
 package bstrees.nodes
 
-class AVLNode<T : Comparable<T>>(data: T) : TreeNode<T, AVLNode<T>>(data) {
+class AVLNode<E : Comparable<E>>(data: E) : TreeNode<E, AVLNode<E>>(data) {
     internal var height = 1
 }

--- a/lib/src/main/kotlin/bstrees/nodes/RBNode.kt
+++ b/lib/src/main/kotlin/bstrees/nodes/RBNode.kt
@@ -1,6 +1,6 @@
 package bstrees.nodes
 
-class RBNode<T : Comparable<T>>(override var data: T) : TreeNode<T, RBNode<T>>() {
+class RBNode<T : Comparable<T>>(data: T) : TreeNode<T, RBNode<T>>(data) {
     enum class Color {
         Red,
         Black

--- a/lib/src/main/kotlin/bstrees/nodes/RBNode.kt
+++ b/lib/src/main/kotlin/bstrees/nodes/RBNode.kt
@@ -1,6 +1,6 @@
 package bstrees.nodes
 
-class RBNode<T : Comparable<T>>(data: T) : TreeNode<T, RBNode<T>>(data) {
+class RBNode<E : Comparable<E>>(data: E) : TreeNode<E, RBNode<E>>(data) {
     enum class Color {
         Red,
         Black

--- a/lib/src/main/kotlin/bstrees/nodes/SimpleNode.kt
+++ b/lib/src/main/kotlin/bstrees/nodes/SimpleNode.kt
@@ -1,3 +1,3 @@
 package bstrees.nodes
 
-class SimpleNode<T : Comparable<T>>(data: T) : TreeNode<T, SimpleNode<T>>(data)
+class SimpleNode<E : Comparable<E>>(data: E) : TreeNode<E, SimpleNode<E>>(data)

--- a/lib/src/main/kotlin/bstrees/nodes/SimpleNode.kt
+++ b/lib/src/main/kotlin/bstrees/nodes/SimpleNode.kt
@@ -1,3 +1,3 @@
 package bstrees.nodes
 
-class SimpleNode<T : Comparable<T>>(override var data: T) : TreeNode<T, SimpleNode<T>>()
+class SimpleNode<T : Comparable<T>>(data: T) : TreeNode<T, SimpleNode<T>>(data)

--- a/lib/src/main/kotlin/bstrees/nodes/TreeNode.kt
+++ b/lib/src/main/kotlin/bstrees/nodes/TreeNode.kt
@@ -1,12 +1,12 @@
 package bstrees.nodes
 
-abstract class TreeNode<T : Comparable<T>, NodeType : TreeNode<T, NodeType>>(data: T) {
-    var data: T = data
+abstract class TreeNode<E : Comparable<E>, N : TreeNode<E, N>>(data: E) {
+    var data: E = data
         internal set
 
-    internal var parent: NodeType? = null
-    var left: NodeType? = null
+    internal var parent: N? = null
+    var left: N? = null
         internal set
-    var right: NodeType? = null
+    var right: N? = null
         internal set
 }

--- a/lib/src/main/kotlin/bstrees/nodes/TreeNode.kt
+++ b/lib/src/main/kotlin/bstrees/nodes/TreeNode.kt
@@ -1,8 +1,9 @@
 package bstrees.nodes
 
-abstract class TreeNode<T : Comparable<T>, NodeType : TreeNode<T, NodeType>> {
-    abstract var data: T
+abstract class TreeNode<T : Comparable<T>, NodeType : TreeNode<T, NodeType>>(data: T) {
+    var data: T = data
         internal set
+
     internal var parent: NodeType? = null
     var left: NodeType? = null
         internal set

--- a/lib/src/main/kotlin/bstrees/repos/JsonRepository.kt
+++ b/lib/src/main/kotlin/bstrees/repos/JsonRepository.kt
@@ -47,8 +47,8 @@ class JsonRepository<T : Comparable<T>,
     // uses hash codes of trees' names as filenames
     // as storing files with arbitrary unicode names can be error-prone
 
-    override fun getNames(): List<String> =
-        File(dirPath).listFiles()?.map {
+    override val names: List<String>
+        get() = File(dirPath).listFiles()?.map {
             Json.decodeFromString<JsonTree>(it.readText()).name
         } ?: listOf()
 

--- a/lib/src/main/kotlin/bstrees/repos/Neo4jRepository.kt
+++ b/lib/src/main/kotlin/bstrees/repos/Neo4jRepository.kt
@@ -65,8 +65,8 @@ class Neo4jRepository<T : Comparable<T>,
     private val session = SessionFactory(neo4jConfig, "bstrees.repos").openSession()
     private val bstType = strategy.bstType.toString()
 
-    override fun getNames(): List<String> =
-        session.loadAll(
+    override val names: List<String>
+        get() = session.loadAll(
             GraphTree::class.java,
             Filter("type", ComparisonOperator.EQUALS, bstType),
             0

--- a/lib/src/main/kotlin/bstrees/repos/Neo4jRepository.kt
+++ b/lib/src/main/kotlin/bstrees/repos/Neo4jRepository.kt
@@ -50,18 +50,18 @@ private class GraphTree(
  * Saves binary search trees in neo4j database.
  * Acts like associative array with trees' names as keys and trees as values.
  *
- * Must be provided with [strategy] so repository knows how to work with specific [TreeType].
+ * Must be provided with [strategy] so repository knows how to work with specific [T].
  *
  * Different tree types can be saved in the same database
  * by creating several Neo4jRepositories with same neo4jConfig.
- * Note that saving trees with same tree type but different data type [T]
+ * Note that saving trees with same tree type but different data type [E]
  * in the same database is error-prone and is not advised.
  */
-class Neo4jRepository<T : Comparable<T>,
-        NodeType : TreeNode<T, NodeType>,
-        TreeType : BinarySearchTree<T, NodeType>>(
-    private val strategy: SerializationStrategy<T, NodeType, TreeType>, neo4jConfig: Configuration
-) : TreeRepository<TreeType> {
+class Neo4jRepository<E : Comparable<E>,
+        N : TreeNode<E, N>,
+        T : BinarySearchTree<E, N>>(
+    private val strategy: SerializationStrategy<E, N, T>, neo4jConfig: Configuration
+) : TreeRepository<T> {
     private val session = SessionFactory(neo4jConfig, "bstrees.repos").openSession()
     private val bstType = strategy.bstType.toString()
 
@@ -72,7 +72,7 @@ class Neo4jRepository<T : Comparable<T>,
             0
         ).map(GraphTree::name)
 
-    override fun get(treeName: String): TreeType? =
+    override fun get(treeName: String): T? =
         session.loadAll(
             GraphTree::class.java,
             Filter("type", ComparisonOperator.EQUALS, bstType).and(
@@ -85,7 +85,7 @@ class Neo4jRepository<T : Comparable<T>,
             }
         }
 
-    override fun set(treeName: String, tree: TreeType): Unit {
+    override fun set(treeName: String, tree: T): Unit {
         remove(treeName) // remove first if already exists
 
         session.save(
@@ -104,14 +104,14 @@ class Neo4jRepository<T : Comparable<T>,
         ).queryStatistics().containsUpdates()
 
 
-    private fun NodeType.toGraphNode(): GraphNode = GraphNode(
+    private fun N.toGraphNode(): GraphNode = GraphNode(
         data = strategy.collectData(this),
         metadata = strategy.collectMetadata(this),
         left = left?.toGraphNode(),
         right = right?.toGraphNode()
     )
 
-    private fun GraphNode.deserialize(parent: NodeType? = null): NodeType {
+    private fun GraphNode.deserialize(parent: N? = null): N {
         val node = strategy.createNode(data)
         strategy.processMetadata(node, metadata)
 

--- a/lib/src/main/kotlin/bstrees/repos/SqlRepository.kt
+++ b/lib/src/main/kotlin/bstrees/repos/SqlRepository.kt
@@ -80,9 +80,10 @@ class SqlRepository<T : Comparable<T>,
         }
     }
 
-    override fun getNames(): List<String> = transaction(db) {
-        DBTree.find(TreesTable.type eq bstType).map(DBTree::name)
-    }
+    override val names: List<String>
+        get() = transaction(db) {
+            DBTree.find(TreesTable.type eq bstType).map(DBTree::name)
+        }
 
     override fun get(treeName: String): TreeType? = transaction(db) {
         DBTree.find(

--- a/lib/src/main/kotlin/bstrees/repos/SqlRepository.kt
+++ b/lib/src/main/kotlin/bstrees/repos/SqlRepository.kt
@@ -56,21 +56,21 @@ internal class DBTree(id: EntityID<Int>) : IntEntity(id) {
  * Saves binary search trees in SQL database [db].
  * Acts like associative array with trees' names as keys and trees as values.
  *
- * Must be provided with [strategy] so repository knows how to work with specific [TreeType].
+ * Must be provided with [strategy] so repository knows how to work with specific [T].
  *
  * Different tree types can be saved in the same [db]
  * by creating several SqlRepositories with same [db].
- * Note that saving trees with same tree type but different data type [T]
+ * Note that saving trees with same tree type but different data type [E]
  * in the same [db] is error-prone and is not advised.
  *
  * Usage of SQLite is not advised as 'ON DELETE CASCADE' doesn't seem to work properly there:
  * after deletion of tree its nodes remain in the table.
  */
-class SqlRepository<T : Comparable<T>,
-        NodeType : TreeNode<T, NodeType>,
-        TreeType : BinarySearchTree<T, NodeType>>(
-    private val strategy: SerializationStrategy<T, NodeType, TreeType>, private val db: Database
-) : TreeRepository<TreeType> {
+class SqlRepository<E : Comparable<E>,
+        N : TreeNode<E, N>,
+        T : BinarySearchTree<E, N>>(
+    private val strategy: SerializationStrategy<E, N, T>, private val db: Database
+) : TreeRepository<T> {
     private val bstType = strategy.bstType.toString()
 
     init {
@@ -85,7 +85,7 @@ class SqlRepository<T : Comparable<T>,
             DBTree.find(TreesTable.type eq bstType).map(DBTree::name)
         }
 
-    override fun get(treeName: String): TreeType? = transaction(db) {
+    override fun get(treeName: String): T? = transaction(db) {
         DBTree.find(
             TreesTable.type eq bstType and (TreesTable.name eq treeName)
         ).firstOrNull()?.let {
@@ -93,7 +93,7 @@ class SqlRepository<T : Comparable<T>,
         }
     }
 
-    override fun set(treeName: String, tree: TreeType): Unit = transaction(db) {
+    override fun set(treeName: String, tree: T): Unit = transaction(db) {
         remove(treeName) // remove first if already exists
 
         val dbTree = DBTree.new {
@@ -112,7 +112,7 @@ class SqlRepository<T : Comparable<T>,
         } ?: false
     }
 
-    private fun NodeType.toDBNode(dbTree: DBTree): DBNode =
+    private fun N.toDBNode(dbTree: DBTree): DBNode =
         DBNode.new {
             data = strategy.collectData(this@toDBNode)
             metadata = strategy.collectMetadata(this@toDBNode)
@@ -121,7 +121,7 @@ class SqlRepository<T : Comparable<T>,
             tree = dbTree
         }
 
-    private fun DBNode.deserialize(parent: NodeType? = null): NodeType {
+    private fun DBNode.deserialize(parent: N? = null): N {
         val node = strategy.createNode(data)
         strategy.processMetadata(node, metadata)
 

--- a/lib/src/main/kotlin/bstrees/repos/TreeRepository.kt
+++ b/lib/src/main/kotlin/bstrees/repos/TreeRepository.kt
@@ -2,18 +2,18 @@ package bstrees.repos
 
 import bstrees.BinarySearchTree
 
-interface TreeRepository<TreeType : BinarySearchTree<*, *>> {
+interface TreeRepository<T : BinarySearchTree<*, *>> {
     /** Gets the names of all trees in the repository */
     val names: List<String>
 
     /** Gets the tree by its name. Returns null if such tree not found */
-    operator fun get(treeName: String): TreeType?
+    operator fun get(treeName: String): T?
 
     /**
      * Adds [tree] to the repository.
      * If tree with [treeName] already exists replaces it with provided one.
      */
-    operator fun set(treeName: String, tree: TreeType)
+    operator fun set(treeName: String, tree: T)
 
     /**
      * Removes tree from the repository.

--- a/lib/src/main/kotlin/bstrees/repos/TreeRepository.kt
+++ b/lib/src/main/kotlin/bstrees/repos/TreeRepository.kt
@@ -4,7 +4,7 @@ import bstrees.BinarySearchTree
 
 interface TreeRepository<TreeType : BinarySearchTree<*, *>> {
     /** Gets the names of all trees in the repository */
-    fun getNames(): List<String>
+    val names: List<String>
 
     /** Gets the tree by its name. Returns null if such tree not found */
     operator fun get(treeName: String): TreeType?

--- a/lib/src/main/kotlin/bstrees/repos/strategies/AVLStrategy.kt
+++ b/lib/src/main/kotlin/bstrees/repos/strategies/AVLStrategy.kt
@@ -6,19 +6,19 @@ import bstrees.nodes.AVLNode
 /**
  * Used to serialize and deserialize [AVLTree].
  *
- * To serialize and deserialize tree's data type [T]
+ * To serialize and deserialize tree's data type [E]
  * strategy must be provided with corresponding functions.
  */
-class AVLStrategy<T : Comparable<T>>(
-    serializeData: (T) -> String, deserializeData: (String) -> T
-) : SerializationStrategy<T, AVLNode<T>, AVLTree<T>>(serializeData, deserializeData) {
+class AVLStrategy<E : Comparable<E>>(
+    serializeData: (E) -> String, deserializeData: (String) -> E
+) : SerializationStrategy<E, AVLNode<E>, AVLTree<E>>(serializeData, deserializeData) {
     override val bstType = BSTType.AVL
 
-    override fun createNode(data: T) = AVLNode(data)
-    override fun createTree() = AVLTree<T>()
+    override fun createNode(data: E) = AVLNode(data)
+    override fun createTree() = AVLTree<E>()
 
-    override fun collectMetadata(node: AVLNode<T>) = node.height.toString()
-    override fun processMetadata(node: AVLNode<T>, metadata: String) {
+    override fun collectMetadata(node: AVLNode<E>) = node.height.toString()
+    override fun processMetadata(node: AVLNode<E>, metadata: String) {
         node.height = metadata.toIntOrNull()
             ?: throw IllegalArgumentException("Metadata must contain node's height")
     }

--- a/lib/src/main/kotlin/bstrees/repos/strategies/RBStrategy.kt
+++ b/lib/src/main/kotlin/bstrees/repos/strategies/RBStrategy.kt
@@ -17,7 +17,11 @@ class RBStrategy<T : Comparable<T>>(
     override fun createNode(data: T) = RBNode(data)
     override fun createTree() = RBTree<T>()
 
-    override fun collectMetadata(node: RBNode<T>) = node.color.toString().first().toString()
+    override fun collectMetadata(node: RBNode<T>) = when (node.color) {
+        RBNode.Color.Red -> "R"
+        RBNode.Color.Black -> "B"
+    }
+
     override fun processMetadata(node: RBNode<T>, metadata: String) {
         when (metadata) {
             "R" -> node.color = RBNode.Color.Red

--- a/lib/src/main/kotlin/bstrees/repos/strategies/RBStrategy.kt
+++ b/lib/src/main/kotlin/bstrees/repos/strategies/RBStrategy.kt
@@ -6,23 +6,23 @@ import bstrees.nodes.RBNode
 /**
  * Used to serialize and deserialize [RBTree].
  *
- * To serialize and deserialize tree's data type [T]
+ * To serialize and deserialize tree's data type [E]
  * strategy must be provided with corresponding functions.
  */
-class RBStrategy<T : Comparable<T>>(
-    serializeData: (T) -> String, deserializeData: (String) -> T
-) : SerializationStrategy<T, RBNode<T>, RBTree<T>>(serializeData, deserializeData) {
+class RBStrategy<E : Comparable<E>>(
+    serializeData: (E) -> String, deserializeData: (String) -> E
+) : SerializationStrategy<E, RBNode<E>, RBTree<E>>(serializeData, deserializeData) {
     override val bstType = BSTType.RB
 
-    override fun createNode(data: T) = RBNode(data)
-    override fun createTree() = RBTree<T>()
+    override fun createNode(data: E) = RBNode(data)
+    override fun createTree() = RBTree<E>()
 
-    override fun collectMetadata(node: RBNode<T>) = when (node.color) {
+    override fun collectMetadata(node: RBNode<E>) = when (node.color) {
         RBNode.Color.Red -> "R"
         RBNode.Color.Black -> "B"
     }
 
-    override fun processMetadata(node: RBNode<T>, metadata: String) {
+    override fun processMetadata(node: RBNode<E>, metadata: String) {
         when (metadata) {
             "R" -> node.color = RBNode.Color.Red
             "B" -> node.color = RBNode.Color.Black

--- a/lib/src/main/kotlin/bstrees/repos/strategies/SerializationStrategy.kt
+++ b/lib/src/main/kotlin/bstrees/repos/strategies/SerializationStrategy.kt
@@ -9,19 +9,19 @@ enum class BSTType {
     RB
 }
 
-abstract class SerializationStrategy<T : Comparable<T>,
-        NodeType : TreeNode<T, NodeType>,
-        TreeType : BinarySearchTree<T, NodeType>>(
-    private val serializeData: (T) -> String,
-    private val deserializeData: (String) -> T
+abstract class SerializationStrategy<E : Comparable<E>,
+        N : TreeNode<E, N>,
+        T : BinarySearchTree<E, N>>(
+    private val serializeData: (E) -> String,
+    private val deserializeData: (String) -> E
 ) {
     abstract val bstType: BSTType
 
-    fun createNode(data: String): NodeType = createNode(deserializeData(data))
-    protected abstract fun createNode(data: T): NodeType
-    abstract fun createTree(): TreeType
+    fun createNode(data: String): N = createNode(deserializeData(data))
+    protected abstract fun createNode(data: E): N
+    abstract fun createTree(): T
 
-    fun collectData(node: NodeType): String = serializeData(node.data)
-    abstract fun collectMetadata(node: NodeType): String
-    abstract fun processMetadata(node: NodeType, metadata: String)
+    fun collectData(node: N): String = serializeData(node.data)
+    abstract fun collectMetadata(node: N): String
+    abstract fun processMetadata(node: N, metadata: String)
 }

--- a/lib/src/main/kotlin/bstrees/repos/strategies/SimpleStrategy.kt
+++ b/lib/src/main/kotlin/bstrees/repos/strategies/SimpleStrategy.kt
@@ -6,17 +6,17 @@ import bstrees.nodes.SimpleNode
 /**
  * Used to serialize and deserialize [SimpleBST].
  *
- * To serialize and deserialize tree's data type [T]
+ * To serialize and deserialize tree's data type [E]
  * strategy must be provided with corresponding functions.
  */
-class SimpleStrategy<T : Comparable<T>>(
-    serializeData: (T) -> String, deserializeData: (String) -> T
-) : SerializationStrategy<T, SimpleNode<T>, SimpleBST<T>>(serializeData, deserializeData) {
+class SimpleStrategy<E : Comparable<E>>(
+    serializeData: (E) -> String, deserializeData: (String) -> E
+) : SerializationStrategy<E, SimpleNode<E>, SimpleBST<E>>(serializeData, deserializeData) {
     override val bstType = BSTType.Simple
 
-    override fun createTree() = SimpleBST<T>()
-    override fun createNode(data: T) = SimpleNode(data)
+    override fun createTree() = SimpleBST<E>()
+    override fun createNode(data: E) = SimpleNode(data)
 
-    override fun collectMetadata(node: SimpleNode<T>) = ""
-    override fun processMetadata(node: SimpleNode<T>, metadata: String) {}
+    override fun collectMetadata(node: SimpleNode<E>) = ""
+    override fun processMetadata(node: SimpleNode<E>, metadata: String) {}
 }

--- a/lib/src/test/kotlin/bstrees/AVLTreeTest.kt
+++ b/lib/src/test/kotlin/bstrees/AVLTreeTest.kt
@@ -1,5 +1,6 @@
 package bstrees
 
+import bstrees.nodes.AVLNode
 import bstrees.nodes.TreeNode
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -22,9 +23,9 @@ class AVLTreeTest {
 
     private lateinit var tree: AVLTree<Int>
 
-    private fun checkAVLInvariant(tree: BinarySearchTree<*, *>): Boolean {
+    private fun checkAVLInvariant(tree: AVLTree<*>): Boolean {
         /** Returns height of [node] or null if tree is not balanced */
-        fun isBalanced(node: TreeNode<*, *>?): Int? {
+        fun isBalanced(node: AVLNode<*>?): Int? {
             if (node == null) return 0
 
             val leftHeight = isBalanced(node.left) ?: return null

--- a/lib/src/test/kotlin/bstrees/RBTreeTest.kt
+++ b/lib/src/test/kotlin/bstrees/RBTreeTest.kt
@@ -21,16 +21,16 @@ class RBTreeTest {
 
     private lateinit var tree: RBTree<Int>
 
-    private fun <T : Comparable<T>> getColor(node: RBNode<T>?) = node?.color ?: RBNode.Color.Black
+    private fun <E : Comparable<E>> getColor(node: RBNode<E>?) = node?.color ?: RBNode.Color.Black
 
-    private fun <T : Comparable<T>> isRed(node: RBNode<T>?) = getColor(node) == RBNode.Color.Red
+    private fun <E : Comparable<E>> isRed(node: RBNode<E>?) = getColor(node) == RBNode.Color.Red
 
-    private fun <T : Comparable<T>> isBlack(node: RBNode<T>?) = !isRed(node)
+    private fun <E : Comparable<E>> isBlack(node: RBNode<E>?) = !isRed(node)
 
-    private fun <T : Comparable<T>> checkRBInvariant(tree: RBTree<T>): Boolean {
-        val blackHeights = HashMap<RBNode<T>, Int>()
+    private fun <E : Comparable<E>> checkRBInvariant(tree: RBTree<E>): Boolean {
+        val blackHeights = HashMap<RBNode<E>, Int>()
 
-        fun checkRBRecursively(node: RBNode<T>?): Boolean {
+        fun checkRBRecursively(node: RBNode<E>?): Boolean {
             node?.let {
                 val leftResult = checkRBRecursively(it.left)
                 val leftBlackHeight = blackHeights[it.left] ?: 1

--- a/lib/src/test/kotlin/bstrees/TestHelpers.kt
+++ b/lib/src/test/kotlin/bstrees/TestHelpers.kt
@@ -2,10 +2,10 @@ package bstrees
 
 import bstrees.nodes.TreeNode
 
-fun <T : Comparable<T>, NodeType : TreeNode<T, NodeType>> traverseInOrder(tree: BinarySearchTree<T, NodeType>): List<T> {
-    val treeList = mutableListOf<T>()
+fun <E : Comparable<E>, N : TreeNode<E, N>> traverseInOrder(tree: BinarySearchTree<E, N>): List<E> {
+    val treeList = mutableListOf<E>()
 
-    fun helper(node: NodeType?) {
+    fun helper(node: N?) {
         node?.let {
             helper(it.left)
             treeList.add(it.data)
@@ -18,7 +18,7 @@ fun <T : Comparable<T>, NodeType : TreeNode<T, NodeType>> traverseInOrder(tree: 
     return treeList
 }
 
-fun <T : Comparable<T>, NodeType : TreeNode<T, NodeType>> checkBSTInvariant(tree: BinarySearchTree<T, NodeType>): Boolean {
+fun <E : Comparable<E>, N : TreeNode<E, N>> checkBSTInvariant(tree: BinarySearchTree<E, N>): Boolean {
     val treeList = traverseInOrder(tree)
 
     for (i in 1 until treeList.size)


### PR DESCRIPTION
- `TreeNode` now accepts `data` in its constructor. Previously `data` was abstract and was overridden the exact same way in all of `TreeNode` implementations
- `TreeRepository` now has computed property `names` instead of fun `getNames`
- Renamed type parameters so their names don't resemble enum classes anymore